### PR TITLE
[look] [bugfix] Correct to `new` Method Signature in Interface Template

### DIFF
--- a/VRGame/Assets/ScriptTemplates/80-MVC Scripts__Interface C#-newInterface.cs.txt
+++ b/VRGame/Assets/ScriptTemplates/80-MVC Scripts__Interface C#-newInterface.cs.txt
@@ -10,6 +10,6 @@ public interface #SCRIPTNAME# : IModel
     /// <summary>
     /// TODO: Change the docstring to match your implementation.
     /// </summary>
-    public void Init();
+    new void Init();
 }
 #NOTRIM#


### PR DESCRIPTION
On the interface template, I replaced the 'public' declaration with 'new' instead. This indicates that the Init() method is overriding an Init() method defined in  base interface its inheriting from. This was necessary to prevent confusion and warnings that was being produced in the console.